### PR TITLE
fix: Rust/Go analyzers fail on relative paths + security check skipped

### DIFF
--- a/src/vibescore/quality_go.py
+++ b/src/vibescore/quality_go.py
@@ -74,11 +74,12 @@ def analyze_quality_go(files: list[FileInfo], root: str) -> CategoryScore:
         if _is_test_file(fi.path):
             continue
 
-        source = _read_source(fi.path)
+        full_path = os.path.join(root, fi.path)
+        source = _read_source(full_path)
         if source is None:
             continue
 
-        rel = os.path.relpath(fi.path, root)
+        rel = fi.path
         lines = source.split("\n")
 
         # VC231: Unchecked errors

--- a/src/vibescore/quality_rs.py
+++ b/src/vibescore/quality_rs.py
@@ -76,11 +76,12 @@ def analyze_quality_rs(files: list[FileInfo], root: str) -> CategoryScore:
         if _is_test_file(fi.path):
             continue
 
-        source = _read_source(fi.path)
+        full_path = os.path.join(root, fi.path)
+        source = _read_source(full_path)
         if source is None:
             continue
 
-        rel = os.path.relpath(fi.path, root)
+        rel = fi.path
         lines = source.split("\n")
 
         # VC221: unwrap() usage

--- a/src/vibescore/security.py
+++ b/src/vibescore/security.py
@@ -96,11 +96,10 @@ def analyze_security(files: list[FileInfo], root: str) -> CategoryScore:
             # VC305: unsafe deserialization
             if _RE_UNSAFE_DESER.search(line):
                 # Allow yaml.load with SafeLoader
-                if "yaml.load" in line and _RE_YAML_SAFE.search(line):
-                    continue
-                issues.append(
-                    Issue("VC305", "warning", "Unsafe deserialization", fi.path, lineno)
-                )
+                if not ("yaml.load" in line and _RE_YAML_SAFE.search(line)):
+                    issues.append(
+                        Issue("VC305", "warning", "Unsafe deserialization", fi.path, lineno)
+                    )
 
             # VC306: eval/exec
             if _RE_EVAL_EXEC.search(line):


### PR DESCRIPTION
## Bug 1: Rust/Go analyzers use relative paths
`fi.path` from `discover_files()` is relative, but `_read_source()` needs absolute paths. The Python and JS analyzers correctly use `os.path.join(root, fi.path)` — Rust and Go don't.

## Bug 2: Security checker skips eval/debug checks
`continue` on safe `yaml.load` skips the remaining VC306 (eval/exec) and VC308 (debug mode) checks for that line. A line like `yaml.load(data, SafeLoader); eval(x)` would miss the eval.

## Tests
All 201 tests pass.